### PR TITLE
notificationmgr: Fix ACG issues

### DIFF
--- a/files/sysbus/com.webos.notification.perm.json.in
+++ b/files/sysbus/com.webos.notification.perm.json.in
@@ -1,5 +1,5 @@
 {
     "com.webos.notification": [
-         "networking", "settings", "applications", "system", "database", "tv.settings"
+         "networking", "settings", "applications", "applications.internal", "system", "database", "tv.settings"
     ]
 }

--- a/files/sysbus/com.webos.notification.role.json.in
+++ b/files/sysbus/com.webos.notification.role.json.in
@@ -12,7 +12,8 @@
                 "com.webos.service.tv.systemproperty",
                 "com.palm.systemservice",
                 "com.webos.applicationManager",
-                "com.webos.appinstaller"
+                "com.webos.appinstaller",
+                "com.webos.lunasend-*"
             ]
         }
     ]


### PR DESCRIPTION
Solves:

Apr 30 16:30:00 qemux86-64 ls-hubd[236]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.lunasend-1589","SRC_APP_ID":"com.webos.notification","EXE":"/usr/sbin/notificationmgr","PID":1588} "com.webos.notification" does not have sufficient outbound permissions to communicate with "com.webos.lunasend-1589" (cmdline: /usr/sbin/notificationmgr)

and

Apr 30 16:29:58 qemux86-64 sam[606]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.webos.notification","CATEGORY":"/","METHOD":"listApps"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>